### PR TITLE
fix: gh token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,5 @@ jobs:
 
       - name: Run diff.sh
         run: ./diff.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> 对于使用 GitHub CLI 的每个步骤，必须将调用 GH_TOKEN 的环境变量设置为具有所需范围的令牌。

https://docs.github.com/zh/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows